### PR TITLE
Make the literals more like erlang/haskell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@ exe_target = purs
 stack_yaml = STACK_YAML="stack.yaml"
 stack = $(stack_yaml) stack
 
+all: build
+
 help: ## Print documentation
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 

--- a/src/Language/PureScript/AST/Binders.hs
+++ b/src/Language/PureScript/AST/Binders.hs
@@ -182,7 +182,7 @@ binderNames = go []
   go ns (TypedBinder _ b) = go ns b
   go ns _ = ns
   lit ns (ObjectLiteral bs) = foldl go ns (map snd bs)
-  lit ns (ArrayLiteral bs) = foldl go ns bs
+  lit ns (ListLiteral bs) = foldl go ns bs
   lit ns _ = ns
 
 isIrrefutable :: Binder -> Bool

--- a/src/Language/PureScript/AST/Literals.hs
+++ b/src/Language/PureScript/AST/Literals.hs
@@ -12,25 +12,25 @@ import Language.PureScript.PSString (PSString)
 --
 data Literal a
   -- |
+  -- A boolean literal
+  --
+  = BooleanLiteral Bool
+  -- |
   -- A numeric literal
   --
-  = NumericLiteral (Either Integer Double)
-  -- |
-  -- A string literal
-  --
-  | StringLiteral PSString
+  | NumericLiteral (Either Integer Double)
   -- |
   -- A character literal
   --
   | CharLiteral Char
   -- |
-  -- A boolean literal
+  -- A string literal
   --
-  | BooleanLiteral Bool
+  | StringLiteral PSString
   -- |
-  -- An array literal
+  -- An list literal
   --
-  | ArrayLiteral [a]
+  | ListLiteral [a]
   -- |
   -- An object literal
   --

--- a/src/Language/PureScript/AST/Traversals.hs
+++ b/src/Language/PureScript/AST/Traversals.hs
@@ -40,7 +40,7 @@ mapGuardedExpr f g (GuardedExpr guards rhs) =
 
 litM :: Monad m => (a -> m a) -> Literal a -> m (Literal a)
 litM go (ObjectLiteral as) = ObjectLiteral <$> traverse (sndM go) as
-litM go (ArrayLiteral as) = ArrayLiteral <$> traverse go as
+litM go (ListLiteral as) = ListLiteral <$> traverse go as
 litM _ other = pure other
 
 everywhereOnValues
@@ -95,7 +95,7 @@ everywhereOnValues f g h = (f', g', h')
   h' other = h other
 
   lit :: (a -> a) -> Literal a -> Literal a
-  lit go (ArrayLiteral as) = ArrayLiteral (fmap go as)
+  lit go (ListLiteral as) = ListLiteral (fmap go as)
   lit go (ObjectLiteral as) = ObjectLiteral (fmap (fmap go) as)
   lit _ other = other
 
@@ -313,7 +313,7 @@ everythingOnValues (<>.) f g h i j = (f', g', h', i', j')
   h' b = h b
 
   lit :: r -> (a -> r) -> Literal a -> r
-  lit r go (ArrayLiteral as) = foldl (<>.) r (fmap go as)
+  lit r go (ListLiteral as) = foldl (<>.) r (fmap go as)
   lit r go (ObjectLiteral as) = foldl (<>.) r (fmap (go . snd) as)
   lit r _ _ = r
 
@@ -398,7 +398,7 @@ everythingWithContextOnValues s0 r0 (<>.) f g h i j = (f'' s0, g'' s0, h'' s0, i
   h' _ _ = r0
 
   lit :: (s -> a -> r) -> s -> Literal a -> r
-  lit go s (ArrayLiteral as) = foldl (<>.) r0 (fmap (go s) as)
+  lit go s (ListLiteral as) = foldl (<>.) r0 (fmap (go s) as)
   lit go s (ObjectLiteral as) = foldl (<>.) r0 (fmap (go s . snd) as)
   lit _ _ _ = r0
 
@@ -482,7 +482,7 @@ everywhereWithContextOnValuesM s0 f g h i j = (f'' s0, g'' s0, h'' s0, i'' s0, j
   h' _ other = return other
 
   lit :: (s -> a -> m a) -> s -> Literal a -> m (Literal a)
-  lit go s (ArrayLiteral as) = ArrayLiteral <$> traverse (go s) as
+  lit go s (ListLiteral as) = ListLiteral <$> traverse (go s) as
   lit go s (ObjectLiteral as) = ObjectLiteral <$> traverse (sndM (go s)) as
   lit _ _ other = return other
 
@@ -584,7 +584,7 @@ everythingWithScope f g h i j = (f'', g'', h'', i'', \s -> snd . j'' s)
   h' _ _ = mempty
 
   lit :: (S.Set ScopedIdent -> a -> r) -> S.Set ScopedIdent -> Literal a -> r
-  lit go s (ArrayLiteral as) = foldMap (go s) as
+  lit go s (ListLiteral as) = foldMap (go s) as
   lit go s (ObjectLiteral as) = foldMap (go s . snd) as
   lit _ _ _ = mempty
 

--- a/src/Language/PureScript/CST/Convert.hs
+++ b/src/Language/PureScript/CST/Convert.hs
@@ -291,7 +291,7 @@ convertExpr fileName = go
         vals = case bs of
           Just (Separated x xs) -> go x : (go . snd <$> xs)
           Nothing -> []
-      positioned ann . AST.Literal (fst ann) $ AST.ArrayLiteral vals
+      positioned ann . AST.Literal (fst ann) $ AST.ListLiteral vals
     ExprRecord z (Wrapped a bs c) -> do
       let
         ann = sourceAnnCommented fileName a c
@@ -414,7 +414,7 @@ convertBinder fileName = go
         vals = case bs of
           Just (Separated x xs) -> go x : (go . snd <$> xs)
           Nothing -> []
-      positioned ann . AST.LiteralBinder (fst ann) $ AST.ArrayLiteral vals
+      positioned ann . AST.LiteralBinder (fst ann) $ AST.ListLiteral vals
     BinderRecord z (Wrapped a bs c) -> do
       let
         ann = sourceAnnCommented fileName a c

--- a/src/Language/PureScript/CodeGen/JS.hs
+++ b/src/Language/PureScript/CodeGen/JS.hs
@@ -275,7 +275,7 @@ moduleToJs (Module _ coms mn _ imps exps foreigns decls) foreign_ =
   literalToValueJS ss (StringLiteral s) = return $ AST.StringLiteral (Just ss) s
   literalToValueJS ss (CharLiteral c) = return $ AST.StringLiteral (Just ss) (fromString [c])
   literalToValueJS ss (BooleanLiteral b) = return $ AST.BooleanLiteral (Just ss) b
-  literalToValueJS ss (ArrayLiteral xs) = AST.ArrayLiteral (Just ss) <$> mapM valueToJs xs
+  literalToValueJS ss (ListLiteral xs) = AST.ListLiteral (Just ss) <$> mapM valueToJs xs
   literalToValueJS ss (ObjectLiteral ps) = AST.ObjectLiteral (Just ss) <$> mapM (sndM valueToJs) ps
 
   -- | Shallow copy an object.
@@ -334,7 +334,7 @@ moduleToJs (Module _ coms mn _ imps exps foreigns decls) foreign_ =
       go _ _ _ = internalError "Invalid arguments to bindersToJs"
 
       failedPatternError :: [Text] -> AST
-      failedPatternError names = AST.Unary Nothing AST.New $ AST.App Nothing (AST.Var Nothing "Error") [AST.Binary Nothing AST.Add (AST.StringLiteral Nothing $ mkString failedPatternMessage) (AST.ArrayLiteral Nothing $ zipWith valueError names vals)]
+      failedPatternError names = AST.Unary Nothing AST.New $ AST.App Nothing (AST.Var Nothing "Error") [AST.Binary Nothing AST.Add (AST.StringLiteral Nothing $ mkString failedPatternMessage) (AST.ListLiteral Nothing $ zipWith valueError names vals)]
 
       failedPatternMessage :: Text
       failedPatternMessage = "Failed pattern match at " <> runModuleName mn <> " " <> displayStartEndPos ss <> ": "
@@ -413,7 +413,7 @@ moduleToJs (Module _ coms mn _ imps exps foreigns decls) foreign_ =
       done'' <- go done' bs'
       js <- binderToJs propVar done'' binder
       return (AST.VariableIntroduction Nothing propVar (Just (accessorString prop (AST.Var Nothing varName))) : js)
-  literalToBinderJS varName done (ArrayLiteral bs) = do
+  literalToBinderJS varName done (ListLiteral bs) = do
     js <- go done 0 bs
     return [AST.IfElse Nothing (AST.Binary Nothing AST.EqualTo (accessorString "length" (AST.Var Nothing varName)) (AST.NumericLiteral Nothing (Left (fromIntegral $ length bs)))) (AST.Block Nothing js) Nothing]
     where

--- a/src/Language/PureScript/CodeGen/JS/Printer.hs
+++ b/src/Language/PureScript/CodeGen/JS/Printer.hs
@@ -37,7 +37,7 @@ literals = mkPattern' match'
   match (StringLiteral _ s) = return $ emit $ prettyPrintStringJS s
   match (BooleanLiteral _ True) = return $ emit "true"
   match (BooleanLiteral _ False) = return $ emit "false"
-  match (ArrayLiteral _ xs) = mconcat <$> sequence
+  match (ListLiteral _ xs) = mconcat <$> sequence
     [ return $ emit "[ "
     , intercalate (emit ", ") <$> forM xs prettyPrintJS'
     , return $ emit " ]"

--- a/src/Language/PureScript/CoreFn/FromJSON.hs
+++ b/src/Language/PureScript/CoreFn/FromJSON.hs
@@ -71,19 +71,19 @@ literalFromJSON t = withObject "Literal" literalFromObj
   literalFromObj o = do
     type_ <- o .: "literalType" :: Parser Text
     case type_ of
-      "IntLiteral"      -> NumericLiteral . Left <$> o .: "value"
-      "NumberLiteral"   -> NumericLiteral . Right <$> o .: "value"
-      "StringLiteral"   -> StringLiteral <$> o .: "value"
-      "CharLiteral"     -> CharLiteral <$> o .: "value"
-      "BooleanLiteral"  -> BooleanLiteral <$> o .: "value"
-      "ArrayLiteral"    -> parseArrayLiteral o
-      "ObjectLiteral"   -> parseObjectLiteral o
-      _                 -> fail ("error parsing Literal: " ++ show o)
+      "BooleanLiteral" -> BooleanLiteral <$> o .: "value"
+      "IntegerLiteral" -> NumericLiteral . Left <$> o .: "value"
+      "FloatLiteral"   -> NumericLiteral . Right <$> o .: "value"
+      "StringLiteral"  -> StringLiteral <$> o .: "value"
+      "CharLiteral"    -> CharLiteral <$> o .: "value"
+      "ListLiteral"    -> parseListLiteral o
+      "ObjectLiteral"  -> parseObjectLiteral o
+      _                -> fail ("error parsing Literal: " ++ show o)
 
-  parseArrayLiteral o = do
+  parseListLiteral o = do
     val <- o .: "value"
     as <- mapM t (V.toList val)
-    return $ ArrayLiteral as
+    return $ ListLiteral as
 
   parseObjectLiteral o = do
     val <- o .: "value"

--- a/src/Language/PureScript/CoreFn/ToJSON.hs
+++ b/src/Language/PureScript/CoreFn/ToJSON.hs
@@ -53,12 +53,12 @@ annToJSON (ss, _, _, m) = object [ T.pack "sourceSpan"  .= sourceSpanToJSON ss
 literalToJSON :: (a -> Value) -> Literal a -> Value
 literalToJSON _ (NumericLiteral (Left n))
   = object
-    [ T.pack "literalType" .= "IntLiteral"
+    [ T.pack "literalType" .= "IntegerLiteral"
     , T.pack "value"       .= n
     ]
 literalToJSON _ (NumericLiteral (Right n))
   = object
-      [ T.pack "literalType"  .= "NumberLiteral"
+      [ T.pack "literalType"  .= "FloatLiteral"
       , T.pack "value"        .= n
       ]
 literalToJSON _ (StringLiteral s)
@@ -76,9 +76,9 @@ literalToJSON _ (BooleanLiteral b)
     [ T.pack "literalType"  .= "BooleanLiteral"
     , T.pack "value"        .= b
     ]
-literalToJSON t (ArrayLiteral xs)
+literalToJSON t (ListLiteral xs)
   = object
-    [ T.pack "literalType"  .= "ArrayLiteral"
+    [ T.pack "literalType"  .= "ListLiteral"
     , T.pack "value"        .= map t xs
     ]
 literalToJSON t (ObjectLiteral xs)

--- a/src/Language/PureScript/CoreFn/Traversals.hs
+++ b/src/Language/PureScript/CoreFn/Traversals.hs
@@ -40,7 +40,7 @@ everywhereOnValues f g h = (f', g', h')
        }
 
   handleLiteral :: (a -> a) -> Literal a -> Literal a
-  handleLiteral i (ArrayLiteral ls) = ArrayLiteral (map i ls)
+  handleLiteral i (ListLiteral ls) = ListLiteral (map i ls)
   handleLiteral i (ObjectLiteral ls) = ObjectLiteral (map (fmap i) ls)
   handleLiteral _ other = other
 
@@ -72,6 +72,6 @@ everythingOnValues (<>.) f g h i = (f', g', h', i')
   i' ca@(CaseAlternative bs (Right val)) = foldl (<>.) (i ca) (map h' bs) <>. g' val
   i' ca@(CaseAlternative bs (Left gs)) = foldl (<>.) (i ca) (map h' bs ++ concatMap (\(grd, val) -> [g' grd, g' val]) gs)
 
-  extractLiteral (ArrayLiteral xs) = xs
+  extractLiteral (ListLiteral xs) = xs
   extractLiteral (ObjectLiteral xs) = map snd xs
   extractLiteral _ = []

--- a/src/Language/PureScript/Environment.hs
+++ b/src/Language/PureScript/Environment.hs
@@ -327,21 +327,21 @@ tyString = primTy "String"
 tyChar :: SourceType
 tyChar = primTy "Char"
 
--- | Type constructor for numbers
-tyNumber :: SourceType
-tyNumber = primTy "Float"
-
 -- | Type constructor for integers
-tyInt :: SourceType
-tyInt = primTy "Integer"
+tyInteger :: SourceType
+tyInteger = primTy "Integer"
+
+-- | Type constructor for floats
+tyFloat :: SourceType
+tyFloat = primTy "Float"
 
 -- | Type constructor for booleans
 tyBoolean :: SourceType
 tyBoolean = primTy "Boolean"
 
--- | Type constructor for arrays
-tyArray :: SourceType
-tyArray = primTy "List"
+-- | Type constructor for lists
+tyList :: SourceType
+tyList = primTy "List"
 
 -- | Type constructor for records
 tyRecord :: SourceType
@@ -410,12 +410,12 @@ allPrimKinds = fold
 primTypes :: M.Map (Qualified (ProperName 'TypeName)) (SourceKind, TypeKind)
 primTypes = M.fromList
   [ (primName "Function", (kindType -:> kindType -:> kindType, ExternData))
-  , (primName "List",    (kindType -:> kindType, ExternData))
+  , (primName "List",     (kindType -:> kindType, ExternData))
   , (primName "Record",   (kindRow kindType -:> kindType, ExternData))
   , (primName "String",   (kindType, ExternData))
   , (primName "Char",     (kindType, ExternData))
-  , (primName "Float",   (kindType, ExternData))
-  , (primName "Integer",      (kindType, ExternData))
+  , (primName "Float",    (kindType, ExternData))
+  , (primName "Integer",  (kindType, ExternData))
   , (primName "Boolean",  (kindType, ExternData))
   , (primName "Partial",  (kindConstraint, ExternData))
   ]

--- a/src/Language/PureScript/Linter/Exhaustive.hs
+++ b/src/Language/PureScript/Linter/Exhaustive.hs
@@ -338,7 +338,7 @@ checkExhaustiveExpr initSS env mn = onExpr initSS
 
   onExpr :: SourceSpan -> Expr -> m Expr
   onExpr _ (UnaryMinus ss e) = UnaryMinus ss <$> onExpr ss e
-  onExpr _ (Literal ss (ArrayLiteral es)) = Literal ss . ArrayLiteral <$> mapM (onExpr ss) es
+  onExpr _ (Literal ss (ListLiteral es)) = Literal ss . ListLiteral <$> mapM (onExpr ss) es
   onExpr _ (Literal ss (ObjectLiteral es)) = Literal ss . ObjectLiteral <$> mapM (sndM (onExpr ss)) es
   onExpr ss (TypeClassDictionaryConstructorApp x e) = TypeClassDictionaryConstructorApp x <$> onExpr ss e
   onExpr ss (Accessor x e) = Accessor x <$> onExpr ss e

--- a/src/Language/PureScript/Pretty/Values.hs
+++ b/src/Language/PureScript/Pretty/Values.hs
@@ -126,7 +126,7 @@ prettyPrintLiteralValue _ (StringLiteral s) = text $ T.unpack $ prettyPrintStrin
 prettyPrintLiteralValue _ (CharLiteral c) = text $ show c
 prettyPrintLiteralValue _ (BooleanLiteral True) = text "true"
 prettyPrintLiteralValue _ (BooleanLiteral False) = text "false"
-prettyPrintLiteralValue d (ArrayLiteral xs) = list '[' ']' (prettyPrintValue (d - 1)) xs
+prettyPrintLiteralValue d (ListLiteral xs) = list '[' ']' (prettyPrintValue (d - 1)) xs
 prettyPrintLiteralValue d (ObjectLiteral ps) = prettyPrintObject (d - 1) $ second Just `map` ps
 
 prettyPrintDeclaration :: Int -> Declaration -> Box
@@ -216,7 +216,7 @@ prettyPrintLiteralBinder (ObjectLiteral bs) =
   where
   prettyPrintObjectPropertyBinder :: (PSString, Binder) -> Text
   prettyPrintObjectPropertyBinder (key, binder) = prettyPrintObjectKey key Monoid.<> ": " Monoid.<> prettyPrintBinder binder
-prettyPrintLiteralBinder (ArrayLiteral bs) =
+prettyPrintLiteralBinder (ListLiteral bs) =
   "[ "
   Monoid.<> T.intercalate ", " (map prettyPrintBinder bs)
   Monoid.<> " ]"

--- a/src/Language/PureScript/Renamer.hs
+++ b/src/Language/PureScript/Renamer.hs
@@ -164,7 +164,7 @@ renameInValue (Let ann ds v) =
 -- Renames within literals.
 --
 renameInLiteral :: (a -> Rename a) -> Literal a -> Rename (Literal a)
-renameInLiteral rename (ArrayLiteral bs) = ArrayLiteral <$> traverse rename bs
+renameInLiteral rename (ListLiteral bs) = ListLiteral <$> traverse rename bs
 renameInLiteral rename (ObjectLiteral bs) = ObjectLiteral <$> traverse (sndM rename) bs
 renameInLiteral _ l = return l
 

--- a/tests/TestCoreFn.hs
+++ b/tests/TestCoreFn.hs
@@ -97,7 +97,7 @@ spec = context "CoreFnFromJsonTest" $ do
                 , NonRec ann (Ident "x3") $ Literal ann (StringLiteral (mkString "abc"))
                 , NonRec ann (Ident "x4") $ Literal ann (CharLiteral 'c')
                 , NonRec ann (Ident "x5") $ Literal ann (BooleanLiteral True)
-                , NonRec ann (Ident "x6") $ Literal ann (ArrayLiteral [Literal ann (CharLiteral 'a')])
+                , NonRec ann (Ident "x6") $ Literal ann (ListLiteral [Literal ann (CharLiteral 'a')])
                 , NonRec ann (Ident "x7") $ Literal ann (ObjectLiteral [(mkString "a", Literal ann (CharLiteral 'a'))])
                 ]
       parseMod m `shouldSatisfy` isSuccess

--- a/tests/TestDocs.hs
+++ b/tests/TestDocs.hs
@@ -637,8 +637,8 @@ testCases =
 
   , ("ExplicitTypeSignatures",
       [ ValueShouldHaveTypeSignature (n "ExplicitTypeSignatures") "explicit" (hasTypeVar "something")
-      , ValueShouldHaveTypeSignature (n "ExplicitTypeSignatures") "anInt"    (P.tyInt `P.eqType`)
-      , ValueShouldHaveTypeSignature (n "ExplicitTypeSignatures") "aNumber"  (P.tyNumber `P.eqType`)
+      , ValueShouldHaveTypeSignature (n "ExplicitTypeSignatures") "anInt"    (P.tyInteger `P.eqType`)
+      , ValueShouldHaveTypeSignature (n "ExplicitTypeSignatures") "aNumber"  (P.tyFloat `P.eqType`)
       ])
 
   , ("ConstrainedArgument",


### PR DESCRIPTION
- Rename 'tyInt' to 'tyInteger'
- Rename 'tyNumber' to 'tyFloat'
- Rename 'ArrayLiteral' to 'ListLiteral'
- Rename 'NumberLiteral' to 'FloatLiteral'